### PR TITLE
Hide Cesium ion token in env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Example environment variables for Cesium Ion
+VITE_CESIUM_ION_ACCESS_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Environment variables
+.env
+.env.*
+!.env.example

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 
+## Cesium Ion access token
+
+Set your Cesium Ion access token in a `.env` file at the project root:
+
+```bash
+VITE_CESIUM_ION_ACCESS_TOKEN=your_token_here
+```
+
+Copy `.env.example` to `.env` and replace the placeholder value. The `.env` file
+is gitignored so your token remains private.
+
 Currently, two official plugins are available:
 
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh

--- a/src/CesiumViewer.tsx
+++ b/src/CesiumViewer.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useRef } from 'react'
-import { Viewer } from 'cesium'
+import { Viewer, Ion } from 'cesium'
 import 'cesium/Build/Cesium/Widgets/widgets.css'
+
+const ionToken = import.meta.env.VITE_CESIUM_ION_ACCESS_TOKEN
+if (ionToken) {
+  Ion.defaultAccessToken = ionToken
+}
 
 const CesiumViewer = () => {
   const containerRef = useRef<HTMLDivElement>(null)

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_CESIUM_ION_ACCESS_TOKEN?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}


### PR DESCRIPTION
## Summary
- load Cesium Ion access token from `import.meta.env`
- add `.env.example` and ignore real `.env`
- document the token setup in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing packages)*


------
https://chatgpt.com/codex/tasks/task_e_684072d5193c832f9890246d1d799ead