### PR TITLE
Add building footprint drawing

### DIFF
--- a/src/CesiumViewer.tsx
+++ b/src/CesiumViewer.tsx
@@ -4,8 +4,21 @@ import {
   Ion,
   createWorldTerrainAsync,
   createOsmBuildingsAsync,
+  ScreenSpaceEventHandler,
+  ScreenSpaceEventType,
+  Color,
+  Cartesian3,
+  Cartographic,
+  HeightReference,
+  Entity,
+  Cesium3DTileFeature,
+  BoundingSphere,
 } from 'cesium'
 import 'cesium/Build/Cesium/Widgets/widgets.css'
+
+interface FeatureWithBoundingSphere extends Cesium3DTileFeature {
+  boundingSphere: BoundingSphere
+}
 
 const ionToken = import.meta.env.VITE_CESIUM_ION_ACCESS_TOKEN
 if (ionToken) {
@@ -21,6 +34,8 @@ const CesiumViewer = () => {
     }
 
     let viewer: Viewer | undefined
+    let handler: ScreenSpaceEventHandler | undefined
+    let footprintEntity: Entity | undefined
 
     const initialize = async () => {
       const terrainProvider = await createWorldTerrainAsync()
@@ -33,6 +48,47 @@ const CesiumViewer = () => {
         console.error('Error loading OSM Buildings', error)
       }
 
+      handler = new ScreenSpaceEventHandler(viewer.scene.canvas)
+      handler.setInputAction((click: ScreenSpaceEventHandler.PositionedEvent) => {
+        if (!viewer) {
+          return
+        }
+
+        const picked = viewer.scene.pick(click.position)
+        if (!picked || !(picked instanceof Cesium3DTileFeature)) {
+          return
+        }
+
+        const feature = picked as FeatureWithBoundingSphere
+        const bs = feature.boundingSphere
+        if (!bs) {
+          return
+        }
+
+        const centerCart = Cartographic.fromCartesian(bs.center)
+        const metersPerDegree = 111319.9
+        const delta = (bs.radius ?? 1) / metersPerDegree
+
+        const positions = [
+          Cartesian3.fromRadians(centerCart.longitude - delta, centerCart.latitude - delta, 0),
+          Cartesian3.fromRadians(centerCart.longitude + delta, centerCart.latitude - delta, 0),
+          Cartesian3.fromRadians(centerCart.longitude + delta, centerCart.latitude + delta, 0),
+          Cartesian3.fromRadians(centerCart.longitude - delta, centerCart.latitude + delta, 0),
+        ]
+
+        if (footprintEntity) {
+          viewer.entities.remove(footprintEntity)
+        }
+
+        footprintEntity = viewer.entities.add({
+          polygon: {
+            hierarchy: positions,
+            material: Color.YELLOW.withAlpha(0.5),
+            heightReference: HeightReference.CLAMP_TO_GROUND,
+          },
+        })
+      }, ScreenSpaceEventType.LEFT_CLICK)
+
       viewer.camera.flyTo({
         destination: Cesium.Cartesian3.fromDegrees(-123.102943, 49.271094, 4000),
       })
@@ -41,6 +97,7 @@ const CesiumViewer = () => {
     initialize()
 
     return () => {
+      handler?.destroy()
       viewer?.destroy()
     }
   }, [])

--- a/src/CesiumViewer.tsx
+++ b/src/CesiumViewer.tsx
@@ -72,8 +72,9 @@ const CesiumViewer = () => {
         }
 
         const centerCart = Cartographic.fromCartesian(bs.center)
-        const metersPerDegree = 111319.9
-        const deltaRad = ((bs.radius ?? 1) / metersPerDegree) * (Math.PI / 180)
+        // use earth radius in meters for radian conversion
+        const earthRadius = 6378137
+        const deltaRad = ((bs.radius ?? 1) + 10) / earthRadius
 
         const positions = [
           Cartesian3.fromRadians(centerCart.longitude - deltaRad, centerCart.latitude - deltaRad, 0),


### PR DESCRIPTION
## Summary
- set up ScreenSpaceEventHandler for building selection in Cesium viewer
- draw a polygon footprint based on the picked building's bounding sphere

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68408861bc0c832f9770003eec352b86