### PR TITLE
Add simple Cesium line drawing tool

### DIFF
--- a/src/CesiumViewer.tsx
+++ b/src/CesiumViewer.tsx
@@ -47,6 +47,7 @@ const CesiumViewer = () => {
             positions: [startPositionRef.current!, position],
             width: 2,
             material: Color.YELLOW,
+            clampToGround: true,
           },
         })
         handler.destroy()
@@ -95,6 +96,11 @@ const CesiumViewer = () => {
           position: 'absolute',
           top: 0,
           left: 0,
+          bottom: 0,
+          width: '60px',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '8px',
           padding: '8px',
           backgroundColor: 'rgba(0,0,0,0.3)',
         }}


### PR DESCRIPTION
## Summary
- add a small toolbar to start line drawing mode
- allow user to draw a yellow line with two clicks on the terrain

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684097e499c0832f8136a2b8faff2af6