### PR TITLE
Keep draw line tool active for consecutive lines

### DIFF
--- a/src/CesiumViewer.tsx
+++ b/src/CesiumViewer.tsx
@@ -85,8 +85,9 @@ const CesiumViewer = () => {
         })
         addAnchor(startPositionRef.current!)
         addAnchor(position)
-        handler.destroy()
-        drawHandlerRef.current = null
+        // prepare for drawing the next line without leaving line mode
+        startPositionRef.current = null
+        firstClick = true
       }
     }, ScreenSpaceEventType.LEFT_CLICK)
   }


### PR DESCRIPTION
## Summary
- keep the draw-line handler alive after completing a line so the user can draw multiple lines consecutively

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840a0e8b3b0832faf6e06a2e8b5e1e4