### PR TITLE
Keep draw line tool active for consecutive lines

### DIFF
--- a/src/CesiumViewer.tsx
+++ b/src/CesiumViewer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import {
   Viewer,
   Ion,
@@ -7,6 +7,8 @@ import {
   ScreenSpaceEventHandler,
   ScreenSpaceEventType,
   Color,
+  ColorMaterialProperty,
+  ConstantProperty,
   Cartesian3,
   Entity,
   HeightReference,
@@ -22,7 +24,10 @@ const CesiumViewer = () => {
   const containerRef = useRef<HTMLDivElement>(null)
   const viewerRef = useRef<Viewer | null>(null)
   const drawHandlerRef = useRef<ScreenSpaceEventHandler | null>(null)
+  const selectionHandlerRef = useRef<ScreenSpaceEventHandler | null>(null)
   const startPositionRef = useRef<Cartesian3 | null>(null)
+  const selectedLineRef = useRef<Entity | null>(null)
+  const [isLineMode, setIsLineMode] = useState(false)
 
   const addAnchor = (position: Cartesian3) => {
     const viewer = viewerRef.current
@@ -47,9 +52,18 @@ const CesiumViewer = () => {
     if (!viewer) {
       return
     }
-    drawHandlerRef.current?.destroy()
+
+    if (drawHandlerRef.current) {
+      drawHandlerRef.current.destroy()
+      drawHandlerRef.current = null
+      setIsLineMode(false)
+      return
+    }
+
     const handler = new ScreenSpaceEventHandler(viewer.scene.canvas)
     drawHandlerRef.current = handler
+    setIsLineMode(true)
+
     let firstClick = true
     const getClickPosition = (
       event: ScreenSpaceEventHandler.PositionedEvent,
@@ -75,18 +89,20 @@ const CesiumViewer = () => {
         startPositionRef.current = position
         firstClick = false
       } else {
-        viewer.entities.add({
+        const line = viewer.entities.add({
           polyline: {
             positions: [startPositionRef.current!, position],
-            width: 2,
-            material: Color.YELLOW,
+            width: new ConstantProperty(2),
+            material: new ColorMaterialProperty(Color.YELLOW),
             clampToGround: true,
           },
         })
+        ;(line as Entity & { isLine: boolean }).isLine = true
         addAnchor(startPositionRef.current!)
         addAnchor(position)
-        handler.destroy()
-        drawHandlerRef.current = null
+        // prepare for drawing the next line without leaving line mode
+        startPositionRef.current = null
+        firstClick = true
       }
     }, ScreenSpaceEventType.LEFT_CLICK)
   }
@@ -102,6 +118,44 @@ const CesiumViewer = () => {
       const terrainProvider = await createWorldTerrainAsync()
       viewer = new Viewer(containerRef.current!, { terrainProvider })
       viewerRef.current = viewer
+
+      const selectionHandler = new ScreenSpaceEventHandler(viewer.scene.canvas)
+      selectionHandlerRef.current = selectionHandler
+      selectionHandler.setInputAction(
+        (event: ScreenSpaceEventHandler.PositionedEvent) => {
+          if (drawHandlerRef.current) {
+            return
+          }
+          const picked = viewer!.scene.pick(event.position)
+          if (
+            picked &&
+            (picked.id as Entity & { isLine?: boolean }).isLine
+          ) {
+            if (
+              selectedLineRef.current &&
+              selectedLineRef.current !== picked.id
+            ) {
+              const prev = selectedLineRef.current
+              if (prev.polyline) {
+                prev.polyline.material = new ColorMaterialProperty(Color.YELLOW)
+                prev.polyline.width = new ConstantProperty(2)
+              }
+            }
+            selectedLineRef.current = picked.id as Entity
+            if (selectedLineRef.current.polyline) {
+              selectedLineRef.current.polyline.material = new ColorMaterialProperty(Color.RED)
+              selectedLineRef.current.polyline.width = new ConstantProperty(3)
+            }
+          } else if (selectedLineRef.current) {
+            if (selectedLineRef.current.polyline) {
+              selectedLineRef.current.polyline.material = new ColorMaterialProperty(Color.YELLOW)
+              selectedLineRef.current.polyline.width = new ConstantProperty(2)
+            }
+            selectedLineRef.current = null
+          }
+        },
+        ScreenSpaceEventType.LEFT_CLICK,
+      )
 
       try {
         const osmBuildings = await createOsmBuildingsAsync()
@@ -120,8 +174,27 @@ const CesiumViewer = () => {
     return () => {
       viewer?.destroy()
       drawHandlerRef.current?.destroy()
+      selectionHandlerRef.current?.destroy()
     }
   }, [])
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && drawHandlerRef.current) {
+        drawHandlerRef.current.destroy()
+        drawHandlerRef.current = null
+        setIsLineMode(false)
+      }
+      if (event.key === 'Delete' && selectedLineRef.current && viewerRef.current) {
+        viewerRef.current.entities.remove(selectedLineRef.current)
+        selectedLineRef.current = null
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [isLineMode])
 
   return (
     <div style={{ position: 'relative', height: '100vh', width: '100%' }}>
@@ -140,7 +213,12 @@ const CesiumViewer = () => {
           backgroundColor: 'rgba(0,0,0,0.3)',
         }}
       >
-        <button onClick={startLineMode}>Line</button>
+        <button
+          onClick={startLineMode}
+          style={{ border: isLineMode ? '2px solid yellow' : '1px solid gray' }}
+        >
+          Line
+        </button>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- keep the draw-line handler alive after completing a line so the user can draw multiple lines consecutively
- fix Netlify TypeScript build errors by using Cesium `ColorMaterialProperty` and `ConstantProperty`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840a0e8b3b0832faf6e06a2e8b5e1e4