### PR TITLE
Refactor line drawing into dedicated component

### DIFF
--- a/src/CesiumViewer.tsx
+++ b/src/CesiumViewer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import {
   Viewer,
   Ion,
@@ -17,6 +17,7 @@ if (ionToken) {
 const CesiumViewer = () => {
   const containerRef = useRef<HTMLDivElement>(null)
   const viewerRef = useRef<Viewer | null>(null)
+  const [viewer, setViewer] = useState<Viewer | null>(null)
 
   useEffect(() => {
     if (!containerRef.current) {
@@ -29,6 +30,7 @@ const CesiumViewer = () => {
       const terrainProvider = await createWorldTerrainAsync()
       viewer = new Viewer(containerRef.current!, { terrainProvider })
       viewerRef.current = viewer
+      setViewer(viewer)
 
       try {
         const osmBuildings = await createOsmBuildingsAsync()
@@ -46,13 +48,14 @@ const CesiumViewer = () => {
 
     return () => {
       viewer?.destroy()
+      setViewer(null)
     }
   }, [])
 
   return (
     <div style={{ position: 'relative', height: '100vh', width: '100%' }}>
       <div ref={containerRef} style={{ height: '100%', width: '100%' }} />
-      <LineDrawer viewerRef={viewerRef} />
+      <LineDrawer viewer={viewer} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- move all line drawing and selection logic into new `LineDrawer` component
- simplify `CesiumViewer` to initialize viewer and render `LineDrawer`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840b91faaf0832f9c3a1e4cb676168e