### PR TITLE
Enable chained line drawing with right-click reset

### DIFF
--- a/src/LineDrawer.tsx
+++ b/src/LineDrawer.tsx
@@ -178,10 +178,14 @@ const LineDrawer = ({ viewer }: LineDrawerProps) => {
         ]
         ;(startAnchor as Entity & { connectedLines: Set<Entity> }).connectedLines.add(line)
         ;(endAnchor as Entity & { connectedLines: Set<Entity> }).connectedLines.add(line)
-        startPositionRef.current = null
-        firstClick = true
+        startPositionRef.current = position
+        firstClick = false
       }
     }, ScreenSpaceEventType.LEFT_CLICK)
+    handler.setInputAction(() => {
+      startPositionRef.current = null
+      firstClick = true
+    }, ScreenSpaceEventType.RIGHT_CLICK)
   }
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- keep drawing lines by chaining the next segment from the previous end
- allow right-click to reset starting point for a new line

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840bda9b48c832fb0beae1f2d8cfaec