### PR TITLE
Enable chained line drawing with right-click start reset

### DIFF
--- a/src/LineDrawer.tsx
+++ b/src/LineDrawer.tsx
@@ -178,10 +178,20 @@ const LineDrawer = ({ viewer }: LineDrawerProps) => {
         ]
         ;(startAnchor as Entity & { connectedLines: Set<Entity> }).connectedLines.add(line)
         ;(endAnchor as Entity & { connectedLines: Set<Entity> }).connectedLines.add(line)
+        startPositionRef.current = position
+        firstClick = false
+      }
+    }, ScreenSpaceEventType.LEFT_CLICK)
+    handler.setInputAction((event: ScreenSpaceEventHandler.PositionedEvent) => {
+      const position = getClickPosition(event)
+      if (position) {
+        startPositionRef.current = position
+        firstClick = false
+      } else {
         startPositionRef.current = null
         firstClick = true
       }
-    }, ScreenSpaceEventType.LEFT_CLICK)
+    }, ScreenSpaceEventType.RIGHT_CLICK)
   }
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- allow right-click to choose a new starting point when chaining lines

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840bda9b48c832fb0beae1f2d8cfaec