### PR TITLE
Add Area drawing component

### DIFF
--- a/src/Area.tsx
+++ b/src/Area.tsx
@@ -13,7 +13,6 @@ import {
   Entity,
   HeightReference,
   EllipsoidTangentPlane,
-  PolygonPipeline,
   LabelStyle,
   VerticalOrigin,
 } from 'cesium'
@@ -97,23 +96,22 @@ const Area = ({ viewer }: AreaProps) => {
     if (projected.length < 3) {
       return null
     }
-    const area2D = PolygonPipeline.computeArea2D(projected)
+    let signedArea = 0
     let cx = 0
     let cy = 0
-    let factor = 0
     for (let i = 0, j = projected.length - 1; i < projected.length; j = i++) {
       const p0 = projected[j]
       const p1 = projected[i]
       const f = p0.x * p1.y - p1.x * p0.y
-      factor += f
+      signedArea += f
       cx += (p0.x + p1.x) * f
       cy += (p0.y + p1.y) * f
     }
-    const area = Math.abs(area2D)
-    const signedArea = factor * 0.5
+    signedArea *= 0.5
     if (signedArea === 0) {
       return null
     }
+    const area = Math.abs(signedArea)
     cx /= 6 * signedArea
     cy /= 6 * signedArea
     const centroid2D = new Cartesian2(cx, cy)

--- a/src/CesiumViewer.tsx
+++ b/src/CesiumViewer.tsx
@@ -7,7 +7,7 @@ import {
   Cartesian3,
 } from 'cesium'
 import 'cesium/Build/Cesium/Widgets/widgets.css'
-import LineDrawer from './LineDrawer'
+import ToolsPanel from './ToolsPanel'
 
 const ionToken = import.meta.env.VITE_CESIUM_ION_ACCESS_TOKEN
 if (ionToken) {
@@ -55,7 +55,7 @@ const CesiumViewer = () => {
   return (
     <div style={{ position: 'relative', height: '100vh', width: '100%' }}>
       <div ref={containerRef} style={{ height: '100%', width: '100%' }} />
-      <LineDrawer viewer={viewer} />
+      <ToolsPanel viewer={viewer} />
     </div>
   )
 }

--- a/src/ToolsPanel.tsx
+++ b/src/ToolsPanel.tsx
@@ -1,0 +1,31 @@
+import { Viewer } from 'cesium'
+import LineDrawer from './LineDrawer'
+import Area from './Area'
+
+interface ToolsPanelProps {
+  viewer: Viewer | null
+}
+
+const ToolsPanel = ({ viewer }: ToolsPanelProps) => {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        bottom: 0,
+        width: '60px',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '8px',
+        padding: '8px',
+        backgroundColor: 'rgba(0,0,0,0.3)',
+      }}
+    >
+      <LineDrawer viewer={viewer} />
+      <Area viewer={viewer} />
+    </div>
+  )
+}
+
+export default ToolsPanel


### PR DESCRIPTION
## Summary
- introduce an `Area` drawing component based on `LineDrawer`
- combine Area and Line tools into a new `ToolsPanel`
- render the new panel in `CesiumViewer`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840f405b5ec832f825c2b59423a4308