### PR TITLE
Refactor drawing logic into reusable modules

### DIFF
--- a/src/LineDrawer.tsx
+++ b/src/LineDrawer.tsx
@@ -1,5 +1,5 @@
 // Line drawing component extracted from CesiumViewer
-import { useState, useRef, useEffect, useCallback } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import {
   Viewer,
   ScreenSpaceEventHandler,
@@ -10,8 +10,8 @@ import {
   ConstantProperty,
   Cartesian3,
   Entity,
-  HeightReference,
 } from 'cesium'
+import { useDrawingEntities } from './hooks/useDrawingEntities'
 
 interface LineDrawerProps {
   viewer: Viewer | null
@@ -26,103 +26,20 @@ const LineDrawer = ({ viewer }: LineDrawerProps) => {
   const mousePositionRef = useRef<Cartesian3 | null>(null)
   const selectedLineRef = useRef<Entity | null>(null)
   const selectedAnchorRef = useRef<Entity | null>(null)
-  const anchorsRef = useRef<Entity[]>([])
   const [isLineMode, setIsLineMode] = useState(false)
 
-  const highlightLine = (line: Entity) => {
-    if (line.polyline) {
-      line.polyline.material = new ColorMaterialProperty(Color.RED)
-      line.polyline.width = new ConstantProperty(3)
-    }
-  }
+  const {
+    anchorsRef,
+    highlightLine,
+    unhighlightLine,
+    highlightAnchor,
+    unhighlightAnchor,
+    addAnchor,
+    removeLine,
+    removeAnchor,
+  } = useDrawingEntities(viewer)
 
-  const unhighlightLine = (line: Entity) => {
-    if (line.polyline) {
-      line.polyline.material = new ColorMaterialProperty(Color.YELLOW)
-      line.polyline.width = new ConstantProperty(2)
-    }
-  }
-
-  const highlightAnchor = (anchor: Entity) => {
-    if (anchor.point) {
-      anchor.point.color = new ConstantProperty(Color.RED)
-      anchor.point.pixelSize = new ConstantProperty(10)
-    }
-  }
-
-  const unhighlightAnchor = (anchor: Entity) => {
-    if (anchor.point) {
-      anchor.point.color = new ConstantProperty(Color.ORANGE)
-      anchor.point.pixelSize = new ConstantProperty(8)
-    }
-  }
-
-  const removeLine = useCallback(
-    (line: Entity) => {
-    if (!viewer) {
-      return
-    }
-    viewer.entities.remove(line)
-    const lineWithAnchors = line as Entity & { anchors?: [Entity, Entity] }
-    if (lineWithAnchors.anchors) {
-      for (const anchor of lineWithAnchors.anchors) {
-        const a = anchor as Entity & { connectedLines?: Set<Entity> }
-        a.connectedLines?.delete(line)
-        if (!a.connectedLines || a.connectedLines.size === 0) {
-          viewer.entities.remove(a)
-          anchorsRef.current = anchorsRef.current.filter((e) => e !== a)
-          if (selectedAnchorRef.current === a) {
-            selectedAnchorRef.current = null
-          }
-        }
-      }
-    }
-    },
-    [viewer],
-  )
-
-  const removeAnchor = useCallback(
-    (anchor: Entity) => {
-      if (!viewer) {
-        return
-      }
-      viewer.entities.remove(anchor)
-      anchorsRef.current = anchorsRef.current.filter((e) => e !== anchor)
-      const anchorWithLines = anchor as Entity & { connectedLines?: Set<Entity> }
-      if (anchorWithLines.connectedLines) {
-        for (const line of Array.from(anchorWithLines.connectedLines)) {
-          removeLine(line)
-        }
-      }
-    },
-    [removeLine, viewer],
-  )
-
-  const addAnchor = (position: Cartesian3) => {
-    if (!viewer) {
-      return null
-    }
-    for (const existing of anchorsRef.current) {
-      const pos = existing.position?.getValue(viewer.clock.currentTime)
-      if (pos && Cartesian3.distance(pos, position) < 1) {
-        return existing
-      }
-    }
-    const anchor: Entity = viewer.entities.add({
-      position,
-      point: {
-        pixelSize: 8,
-        color: Color.ORANGE,
-        outlineColor: Color.WHITE,
-        outlineWidth: 1,
-        heightReference: HeightReference.CLAMP_TO_GROUND,
-      },
-    })
-    ;(anchor as Entity & { isAnchor: boolean; connectedLines: Set<Entity> }).isAnchor = true
-    ;(anchor as Entity & { isAnchor: boolean; connectedLines: Set<Entity> }).connectedLines = new Set()
-    anchorsRef.current.push(anchor)
-    return anchor
-  }
+  // removeLine, removeAnchor and addAnchor are provided by useDrawingEntities
 
   const startLineMode = () => {
     if (!viewer) {

--- a/src/geometry.ts
+++ b/src/geometry.ts
@@ -1,0 +1,93 @@
+import {
+  Viewer,
+  Cartesian3,
+  Cartesian2,
+  EllipsoidTangentPlane,
+  Cartographic,
+} from 'cesium'
+
+export function computeAreaAndCentroid(
+  viewer: Viewer,
+  positions: Cartesian3[],
+): { area: number; centroid: Cartesian3 } | null {
+  if (positions.length < 3) {
+    return null
+  }
+  const plane = EllipsoidTangentPlane.fromPoints(
+    positions,
+    viewer.scene.globe.ellipsoid,
+  )
+  const projected = plane.projectPointsOntoPlane(positions, [])
+  if (projected.length < 3) {
+    return null
+  }
+  let signedArea = 0
+  let cx = 0
+  let cy = 0
+  for (let i = 0, j = projected.length - 1; i < projected.length; j = i++) {
+    const p0 = projected[j]
+    const p1 = projected[i]
+    const f = p0.x * p1.y - p1.x * p0.y
+    signedArea += f
+    cx += (p0.x + p1.x) * f
+    cy += (p0.y + p1.y) * f
+  }
+  signedArea *= 0.5
+  if (signedArea === 0) {
+    return null
+  }
+  const area = Math.abs(signedArea)
+  cx /= 6 * signedArea
+  cy /= 6 * signedArea
+  const centroid2D = new Cartesian2(cx, cy)
+  const centroid = plane.projectPointOntoEllipsoid(centroid2D, new Cartesian3())
+  return { area, centroid }
+}
+
+export function computeSurfaceAreaAndCentroid(
+  positions: Cartesian3[],
+): { area: number; centroid: Cartesian3 } | null {
+  if (positions.length < 3) {
+    return null
+  }
+  let area = 0
+  const centroid = new Cartesian3(0, 0, 0)
+  const base = positions[0]
+  for (let i = 1; i < positions.length - 1; i++) {
+    const b = positions[i]
+    const c = positions[i + 1]
+    const ab = Cartesian3.subtract(b, base, new Cartesian3())
+    const ac = Cartesian3.subtract(c, base, new Cartesian3())
+    const cross = Cartesian3.cross(ab, ac, new Cartesian3())
+    const triArea = Cartesian3.magnitude(cross) * 0.5
+    area += triArea
+    const triCentroid = Cartesian3.multiplyByScalar(
+      Cartesian3.add(base, Cartesian3.add(b, c, new Cartesian3()), new Cartesian3()),
+      1 / 3,
+      new Cartesian3(),
+    )
+    Cartesian3.multiplyByScalar(triCentroid, triArea, triCentroid)
+    Cartesian3.add(centroid, triCentroid, centroid)
+  }
+  Cartesian3.divideByScalar(centroid, area, centroid)
+  return { area, centroid }
+}
+
+export async function computeAreaWithTerrain(
+  viewer: Viewer,
+  positions: Cartesian3[],
+): Promise<{ area: number; centroid: Cartesian3 } | null> {
+  if (positions.length < 3) {
+    return null
+  }
+  const cartographics = positions.map((p) => Cartographic.fromCartesian(p))
+  try {
+    const sampled = await viewer.scene.sampleHeightMostDetailed(cartographics)
+    const withHeights = sampled.map((c) =>
+      Cartesian3.fromRadians(c.longitude, c.latitude, c.height),
+    )
+    return computeSurfaceAreaAndCentroid(withHeights)
+  } catch {
+    return computeSurfaceAreaAndCentroid(positions)
+  }
+}

--- a/src/hooks/useDrawingEntities.ts
+++ b/src/hooks/useDrawingEntities.ts
@@ -1,0 +1,119 @@
+import { useCallback, useRef } from 'react'
+import {
+  Viewer,
+  Entity,
+  Cartesian3,
+  Color,
+  ColorMaterialProperty,
+  ConstantProperty,
+  HeightReference,
+} from 'cesium'
+
+export function useDrawingEntities(viewer: Viewer | null) {
+  const anchorsRef = useRef<Entity[]>([])
+  const linesRef = useRef<Entity[]>([])
+
+  const highlightLine = useCallback((line: Entity) => {
+    if (line.polyline) {
+      line.polyline.material = new ColorMaterialProperty(Color.RED)
+      line.polyline.width = new ConstantProperty(3)
+    }
+  }, [])
+
+  const unhighlightLine = useCallback((line: Entity) => {
+    if (line.polyline) {
+      line.polyline.material = new ColorMaterialProperty(Color.YELLOW)
+      line.polyline.width = new ConstantProperty(2)
+    }
+  }, [])
+
+  const highlightAnchor = useCallback((anchor: Entity) => {
+    if (anchor.point) {
+      anchor.point.color = new ConstantProperty(Color.RED)
+      anchor.point.pixelSize = new ConstantProperty(10)
+    }
+  }, [])
+
+  const unhighlightAnchor = useCallback((anchor: Entity) => {
+    if (anchor.point) {
+      anchor.point.color = new ConstantProperty(Color.ORANGE)
+      anchor.point.pixelSize = new ConstantProperty(8)
+    }
+  }, [])
+
+  const addAnchor = useCallback(
+    (position: Cartesian3) => {
+      if (!viewer) {
+        return null
+      }
+      for (const existing of anchorsRef.current) {
+        const pos = existing.position?.getValue(viewer.clock.currentTime)
+        if (pos && Cartesian3.distance(pos, position) < 1) {
+          return existing
+        }
+      }
+      const anchor: Entity = viewer.entities.add({
+        position,
+        point: {
+          pixelSize: 8,
+          color: Color.ORANGE,
+          outlineColor: Color.WHITE,
+          outlineWidth: 1,
+          heightReference: HeightReference.CLAMP_TO_GROUND,
+        },
+      })
+      ;(anchor as Entity & { isAnchor: boolean; connectedLines: Set<Entity> }).isAnchor = true
+      ;(anchor as Entity & { isAnchor: boolean; connectedLines: Set<Entity> }).connectedLines = new Set()
+      anchorsRef.current.push(anchor)
+      return anchor
+    },
+    [viewer],
+  )
+
+  const removeLine = useCallback(
+    (line: Entity) => {
+      if (!viewer) return
+      viewer.entities.remove(line)
+      linesRef.current = linesRef.current.filter((l) => l !== line)
+      const lineWithAnchors = line as Entity & { anchors?: [Entity, Entity] }
+      if (lineWithAnchors.anchors) {
+        for (const anchor of lineWithAnchors.anchors) {
+          const a = anchor as Entity & { connectedLines?: Set<Entity> }
+          a.connectedLines?.delete(line)
+          if (!a.connectedLines || a.connectedLines.size === 0) {
+            viewer.entities.remove(a)
+            anchorsRef.current = anchorsRef.current.filter((e) => e !== a)
+          }
+        }
+      }
+    },
+    [viewer],
+  )
+
+  const removeAnchor = useCallback(
+    (anchor: Entity) => {
+      if (!viewer) return
+      viewer.entities.remove(anchor)
+      anchorsRef.current = anchorsRef.current.filter((e) => e !== anchor)
+      const anchorWithLines = anchor as Entity & { connectedLines?: Set<Entity> }
+      if (anchorWithLines.connectedLines) {
+        for (const line of Array.from(anchorWithLines.connectedLines)) {
+          removeLine(line)
+        }
+      }
+    },
+    [removeLine, viewer],
+  )
+
+  return {
+    anchorsRef,
+    linesRef,
+    highlightLine,
+    unhighlightLine,
+    highlightAnchor,
+    unhighlightAnchor,
+    addAnchor,
+    removeLine,
+    removeAnchor,
+  }
+}


### PR DESCRIPTION
## Summary
- share anchor and line management through `useDrawingEntities`
- move area calculations to `geometry.ts`
- update `LineDrawer` and `Area` to leverage the new utilities

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6842154996d8832f99717e50912925b4