### PR TITLE
Implement shared drawing context

### DIFF
--- a/src/Area.tsx
+++ b/src/Area.tsx
@@ -23,7 +23,7 @@ import {
   LabelGraphics,
 } from 'cesium'
 import { computeAreaAndCentroid, computeAreaWithTerrain } from './geometry'
-import { useDrawingEntities } from './hooks/useDrawingEntities'
+import { useDrawing } from './hooks/DrawingContext'
 
 interface AreaProps {
   viewer: Viewer | null
@@ -36,9 +36,6 @@ const Area = ({ viewer }: AreaProps) => {
   const startAnchorRef = useRef<Entity | null>(null)
   const drawingLineRef = useRef<Entity | null>(null)
   const mousePositionRef = useRef<Cartesian3 | null>(null)
-  const selectedLineRef = useRef<Entity | null>(null)
-  const selectedAnchorRef = useRef<Entity | null>(null)
-  const selectedAreaRef = useRef<Entity | null>(null)
   const axisHelperRef = useRef<
     | {
         x: Entity
@@ -71,7 +68,10 @@ const Area = ({ viewer }: AreaProps) => {
     addAnchor,
     removeLine,
     removeAnchor,
-  } = useDrawingEntities(viewer)
+    selectedLineRef,
+    selectedAnchorRef,
+    selectedAreaRef,
+  } = useDrawing()
   const firstAnchorRef = useRef<Entity | null>(null)
   const polygonPositionsRef = useRef<Cartesian3[]>([])
   const [isAreaMode, setIsAreaMode] = useState(false)
@@ -138,7 +138,7 @@ const Area = ({ viewer }: AreaProps) => {
     axisHandlerRef.current?.destroy()
     axisHandlerRef.current = null
     restoreCamera()
-  }, [viewer, restoreCamera, computeAreaWithTerrain])
+  }, [viewer, restoreCamera])
 
   const showAxisHelper = useCallback((area: Entity) => {
     if (!viewer) {
@@ -369,7 +369,7 @@ const Area = ({ viewer }: AreaProps) => {
         removeAxisHelper()
       }
     },
-    [viewer, removeAxisHelper],
+    [viewer, removeAxisHelper, selectedAreaRef],
   )
 
 
@@ -683,7 +683,18 @@ const Area = ({ viewer }: AreaProps) => {
       selectionHandlerRef.current?.destroy()
       selectionHandlerRef.current = null
     }
-  }, [viewer, highlightArea, unhighlightArea])
+  }, [
+    viewer,
+    highlightArea,
+    unhighlightArea,
+    highlightLine,
+    unhighlightLine,
+    highlightAnchor,
+    unhighlightAnchor,
+    selectedLineRef,
+    selectedAnchorRef,
+    selectedAreaRef,
+  ])
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -733,6 +744,10 @@ const Area = ({ viewer }: AreaProps) => {
     viewer,
     highlightArea,
     unhighlightArea,
+    anchorsRef,
+    selectedLineRef,
+    selectedAnchorRef,
+    selectedAreaRef,
   ])
 
   return (

--- a/src/LineDrawer.tsx
+++ b/src/LineDrawer.tsx
@@ -11,7 +11,7 @@ import {
   Cartesian3,
   Entity,
 } from 'cesium'
-import { useDrawingEntities } from './hooks/useDrawingEntities'
+import { useDrawing } from './hooks/DrawingContext'
 
 interface LineDrawerProps {
   viewer: Viewer | null
@@ -24,8 +24,6 @@ const LineDrawer = ({ viewer }: LineDrawerProps) => {
   const startAnchorRef = useRef<Entity | null>(null)
   const drawingLineRef = useRef<Entity | null>(null)
   const mousePositionRef = useRef<Cartesian3 | null>(null)
-  const selectedLineRef = useRef<Entity | null>(null)
-  const selectedAnchorRef = useRef<Entity | null>(null)
   const [isLineMode, setIsLineMode] = useState(false)
 
   const {
@@ -37,9 +35,11 @@ const LineDrawer = ({ viewer }: LineDrawerProps) => {
     addAnchor,
     removeLine,
     removeAnchor,
-  } = useDrawingEntities(viewer)
+    selectedLineRef,
+    selectedAnchorRef,
+  } = useDrawing()
 
-  // removeLine, removeAnchor and addAnchor are provided by useDrawingEntities
+  // removeLine, removeAnchor and addAnchor are provided by DrawingProvider
 
   const startLineMode = () => {
     if (!viewer) {
@@ -274,7 +274,15 @@ const LineDrawer = ({ viewer }: LineDrawerProps) => {
       selectionHandlerRef.current?.destroy()
       selectionHandlerRef.current = null
     }
-  }, [viewer])
+  }, [
+    viewer,
+    highlightLine,
+    unhighlightLine,
+    highlightAnchor,
+    unhighlightAnchor,
+    selectedLineRef,
+    selectedAnchorRef,
+  ])
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -313,7 +321,15 @@ const LineDrawer = ({ viewer }: LineDrawerProps) => {
     return () => {
       window.removeEventListener('keydown', handleKeyDown)
     }
-  }, [isLineMode, removeLine, removeAnchor, viewer])
+  }, [
+    isLineMode,
+    removeLine,
+    removeAnchor,
+    viewer,
+    anchorsRef,
+    selectedLineRef,
+    selectedAnchorRef,
+  ])
 
   return (
     <button

--- a/src/ToolsPanel.tsx
+++ b/src/ToolsPanel.tsx
@@ -1,6 +1,7 @@
 import { Viewer } from 'cesium'
 import LineDrawer from './LineDrawer'
 import Area from './Area'
+import { DrawingProvider } from './hooks/DrawingContext'
 
 interface ToolsPanelProps {
   viewer: Viewer | null
@@ -8,23 +9,25 @@ interface ToolsPanelProps {
 
 const ToolsPanel = ({ viewer }: ToolsPanelProps) => {
   return (
-    <div
-      style={{
-        position: 'absolute',
-        top: 0,
-        left: 0,
-        bottom: 0,
-        width: '60px',
-        display: 'flex',
-        flexDirection: 'column',
-        gap: '8px',
-        padding: '8px',
-        backgroundColor: 'rgba(0,0,0,0.3)',
-      }}
-    >
-      <LineDrawer viewer={viewer} />
-      <Area viewer={viewer} />
-    </div>
+    <DrawingProvider viewer={viewer}>
+      <div
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          bottom: 0,
+          width: '60px',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '8px',
+          padding: '8px',
+          backgroundColor: 'rgba(0,0,0,0.3)',
+        }}
+      >
+        <LineDrawer viewer={viewer} />
+        <Area viewer={viewer} />
+      </div>
+    </DrawingProvider>
   )
 }
 

--- a/src/hooks/DrawingContext.tsx
+++ b/src/hooks/DrawingContext.tsx
@@ -1,0 +1,77 @@
+import {
+  createContext,
+  useContext,
+  useRef,
+  type ReactNode,
+} from 'react'
+import { Viewer, Entity, Cartesian3 } from 'cesium'
+import { useDrawingEntities } from './useDrawingEntities'
+
+export interface DrawingContextType {
+  anchorsRef: React.MutableRefObject<Entity[]>
+  linesRef: React.MutableRefObject<Entity[]>
+  selectedLineRef: React.MutableRefObject<Entity | null>
+  selectedAnchorRef: React.MutableRefObject<Entity | null>
+  selectedAreaRef: React.MutableRefObject<Entity | null>
+  highlightLine: (line: Entity) => void
+  unhighlightLine: (line: Entity) => void
+  highlightAnchor: (anchor: Entity) => void
+  unhighlightAnchor: (anchor: Entity) => void
+  addAnchor: (position: Cartesian3) => Entity | null
+  removeLine: (line: Entity) => void
+  removeAnchor: (anchor: Entity) => void
+}
+
+interface DrawingProviderProps {
+  viewer: Viewer | null
+  children: ReactNode
+}
+
+const DrawingContext = createContext<DrawingContextType | null>(null)
+
+export const DrawingProvider = ({ viewer, children }: DrawingProviderProps) => {
+  const {
+    anchorsRef,
+    linesRef,
+    highlightLine,
+    unhighlightLine,
+    highlightAnchor,
+    unhighlightAnchor,
+    addAnchor,
+    removeLine,
+    removeAnchor,
+  } = useDrawingEntities(viewer)
+
+  const selectedLineRef = useRef<Entity | null>(null)
+  const selectedAnchorRef = useRef<Entity | null>(null)
+  const selectedAreaRef = useRef<Entity | null>(null)
+
+  return (
+    <DrawingContext.Provider
+      value={{
+        anchorsRef,
+        linesRef,
+        selectedLineRef,
+        selectedAnchorRef,
+        selectedAreaRef,
+        highlightLine,
+        unhighlightLine,
+        highlightAnchor,
+        unhighlightAnchor,
+        addAnchor,
+        removeLine,
+        removeAnchor,
+      }}
+    >
+      {children}
+    </DrawingContext.Provider>
+  )
+}
+
+export const useDrawing = () => {
+  const ctx = useContext(DrawingContext)
+  if (!ctx) {
+    throw new Error('useDrawing must be used within DrawingProvider')
+  }
+  return ctx
+}


### PR DESCRIPTION
## Summary
- create DrawingProvider context to share drawing state
- wrap tools in DrawingProvider
- update LineDrawer and Area to use shared state
- include context refs in hook dependencies

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684218c3d0cc832fb1affb31a34d911b