### PR TITLE
Add typed Cesium entity models

### DIFF
--- a/src/entityTypes.ts
+++ b/src/entityTypes.ts
@@ -1,0 +1,16 @@
+import { Entity, Cartesian3 } from 'cesium'
+
+export interface LineEntity extends Entity {
+  isLine: boolean
+  anchors: [AnchorEntity, AnchorEntity]
+}
+
+export interface AnchorEntity extends Entity {
+  isAnchor: boolean
+  connectedLines: Set<LineEntity>
+}
+
+export interface AreaEntity extends Entity {
+  isArea: boolean
+  positions: Cartesian3[]
+}

--- a/src/hooks/DrawingContext.tsx
+++ b/src/hooks/DrawingContext.tsx
@@ -4,22 +4,23 @@ import {
   useRef,
   type ReactNode,
 } from 'react'
-import { Viewer, Entity, Cartesian3 } from 'cesium'
+import { Viewer, Cartesian3 } from 'cesium'
+import type { AnchorEntity, LineEntity, AreaEntity } from '../entityTypes'
 import { useDrawingEntities } from './useDrawingEntities'
 
 export interface DrawingContextType {
-  anchorsRef: React.MutableRefObject<Entity[]>
-  linesRef: React.MutableRefObject<Entity[]>
-  selectedLineRef: React.MutableRefObject<Entity | null>
-  selectedAnchorRef: React.MutableRefObject<Entity | null>
-  selectedAreaRef: React.MutableRefObject<Entity | null>
-  highlightLine: (line: Entity) => void
-  unhighlightLine: (line: Entity) => void
-  highlightAnchor: (anchor: Entity) => void
-  unhighlightAnchor: (anchor: Entity) => void
-  addAnchor: (position: Cartesian3) => Entity | null
-  removeLine: (line: Entity) => void
-  removeAnchor: (anchor: Entity) => void
+  anchorsRef: React.MutableRefObject<AnchorEntity[]>
+  linesRef: React.MutableRefObject<LineEntity[]>
+  selectedLineRef: React.MutableRefObject<LineEntity | null>
+  selectedAnchorRef: React.MutableRefObject<AnchorEntity | null>
+  selectedAreaRef: React.MutableRefObject<AreaEntity | null>
+  highlightLine: (line: LineEntity) => void
+  unhighlightLine: (line: LineEntity) => void
+  highlightAnchor: (anchor: AnchorEntity) => void
+  unhighlightAnchor: (anchor: AnchorEntity) => void
+  addAnchor: (position: Cartesian3) => AnchorEntity | null
+  removeLine: (line: LineEntity) => void
+  removeAnchor: (anchor: AnchorEntity) => void
 }
 
 interface DrawingProviderProps {
@@ -42,9 +43,9 @@ export const DrawingProvider = ({ viewer, children }: DrawingProviderProps) => {
     removeAnchor,
   } = useDrawingEntities(viewer)
 
-  const selectedLineRef = useRef<Entity | null>(null)
-  const selectedAnchorRef = useRef<Entity | null>(null)
-  const selectedAreaRef = useRef<Entity | null>(null)
+  const selectedLineRef = useRef<LineEntity | null>(null)
+  const selectedAnchorRef = useRef<AnchorEntity | null>(null)
+  const selectedAreaRef = useRef<AreaEntity | null>(null)
 
   return (
     <DrawingContext.Provider


### PR DESCRIPTION
## Summary
- define explicit interfaces `AnchorEntity`, `LineEntity` and `AreaEntity`
- use the new types throughout drawing utilities
- cast created entities to their explicit type for safer property access

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68421ba76960832f970f765c5bd59586