### PR TITLE
Add cleanup for Cesium event handlers

### DIFF
--- a/src/Area.tsx
+++ b/src/Area.tsx
@@ -741,6 +741,18 @@ const Area = ({ viewer }: AreaProps) => {
     selectedAreaRef,
   ])
 
+  useEffect(() => {
+    return () => {
+      drawHandlerRef.current?.destroy()
+      drawHandlerRef.current = null
+      selectionHandlerRef.current?.destroy()
+      selectionHandlerRef.current = null
+      axisHandlerRef.current?.destroy()
+      axisHandlerRef.current = null
+      removeAxisHelper()
+    }
+  }, [removeAxisHelper])
+
   return (
     <button
       onClick={startAreaMode}

--- a/src/LineDrawer.tsx
+++ b/src/LineDrawer.tsx
@@ -324,6 +324,15 @@ const LineDrawer = ({ viewer }: LineDrawerProps) => {
     selectedAnchorRef,
   ])
 
+  useEffect(() => {
+    return () => {
+      drawHandlerRef.current?.destroy()
+      drawHandlerRef.current = null
+      selectionHandlerRef.current?.destroy()
+      selectionHandlerRef.current = null
+    }
+  }, [])
+
   return (
     <button
       onClick={startLineMode}


### PR DESCRIPTION
## Summary
- ensure LineDrawer cleans up Cesium event handlers when unmounting
- ensure Area cleans up all handlers, including axis helpers, when unmounting

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684223ebd3a4832f9c717bb573829e68