### PR TITLE
Refactor ToolsPanel styles

### DIFF
--- a/src/ToolsPanel.module.css
+++ b/src/ToolsPanel.module.css
@@ -1,0 +1,12 @@
+.panel {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 60px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px;
+  background-color: rgba(0, 0, 0, 0.3);
+}

--- a/src/ToolsPanel.tsx
+++ b/src/ToolsPanel.tsx
@@ -2,6 +2,7 @@ import { Viewer } from 'cesium'
 import LineDrawer from './LineDrawer'
 import Area from './Area'
 import { DrawingProvider } from './hooks/DrawingContext'
+import styles from './ToolsPanel.module.css'
 
 interface ToolsPanelProps {
   viewer: Viewer | null
@@ -10,20 +11,7 @@ interface ToolsPanelProps {
 const ToolsPanel = ({ viewer }: ToolsPanelProps) => {
   return (
     <DrawingProvider viewer={viewer}>
-      <div
-        style={{
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          bottom: 0,
-          width: '60px',
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '8px',
-          padding: '8px',
-          backgroundColor: 'rgba(0,0,0,0.3)',
-        }}
-      >
+      <div className={styles.panel}>
         <LineDrawer viewer={viewer} />
         <Area viewer={viewer} />
       </div>


### PR DESCRIPTION
## Summary
- refactor ToolsPanel to use CSS module instead of inline styles

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68422050fea8832f9e14e8aff7ca10d7