### PR TITLE
Add building hide context menu

### DIFF
--- a/src/BuildingContextMenu.tsx
+++ b/src/BuildingContextMenu.tsx
@@ -1,0 +1,29 @@
+import type { CSSProperties } from 'react'
+
+interface BuildingContextMenuProps {
+  x: number
+  y: number
+  onHide: () => void
+}
+
+const menuStyle: CSSProperties = {
+  position: 'absolute',
+  backgroundColor: 'white',
+  color: 'black',
+  padding: '4px',
+  border: '1px solid gray',
+  zIndex: 1000,
+}
+
+const BuildingContextMenu = ({ x, y, onHide }: BuildingContextMenuProps) => {
+  return (
+    <div
+      style={{ ...menuStyle, left: x, top: y }}
+      onContextMenu={(e) => e.preventDefault()}
+    >
+      <button onClick={onHide}>Hide</button>
+    </div>
+  )
+}
+
+export default BuildingContextMenu


### PR DESCRIPTION
## Summary
- add a simple context menu component with a Hide action
- attach right-click handler in CesiumViewer to pick buildings
- display the menu on right click and hide selected buildings

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6842926a9da4832f99f82ac1e7229081