### PR TITLE
Add Cesium ion upload support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,13 @@
 import CesiumViewer from './CesiumViewer'
+import ModelUploader from './ModelUploader'
 
 function App() {
-  return <CesiumViewer />
+  return (
+    <>
+      <CesiumViewer />
+      <ModelUploader />
+    </>
+  )
 }
 
 export default App

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,7 @@
 import CesiumViewer from './CesiumViewer'
-import ModelUploader from './ModelUploader'
 
 function App() {
-  return (
-    <>
-      <CesiumViewer />
-      <ModelUploader />
-    </>
-  )
+  return <CesiumViewer />
 }
 
 export default App

--- a/src/CesiumViewer.tsx
+++ b/src/CesiumViewer.tsx
@@ -12,6 +12,7 @@ import {
 import 'cesium/Build/Cesium/Widgets/widgets.css'
 import ToolsPanel from './ToolsPanel'
 import BuildingContextMenu from './BuildingContextMenu'
+import ModelUploader from './ModelUploader'
 
 const ionToken = import.meta.env.VITE_CESIUM_ION_ACCESS_TOKEN
 if (ionToken) {
@@ -95,6 +96,7 @@ const CesiumViewer = () => {
         onContextMenu={(e) => e.preventDefault()}
       />
       <ToolsPanel viewer={viewer} />
+      <ModelUploader viewer={viewer} />
       {contextMenu && (
         <BuildingContextMenu
           x={contextMenu.x}

--- a/src/ModelUploader.tsx
+++ b/src/ModelUploader.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'react'
+import { uploadModelToIon } from './ionUpload'
+
+const ModelUploader = () => {
+  const [uploading, setUploading] = useState(false)
+  const [assetId, setAssetId] = useState<number | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    setError(null)
+    setUploading(true)
+    try {
+      const id = await uploadModelToIon(file)
+      setAssetId(id)
+    } catch (err) {
+      setError((err as Error).message)
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <input type="file" onChange={handleFileChange} accept=".gltf,.glb,.obj,.fbx" />
+      {uploading && <p>Uploading...</p>}
+      {assetId && <p>Uploaded asset ID: {assetId}</p>}
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+    </div>
+  )
+}
+
+export default ModelUploader

--- a/src/ionUpload.ts
+++ b/src/ionUpload.ts
@@ -44,6 +44,7 @@ export async function uploadModelToIon(file: File): Promise<number> {
     headers: {
       Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
+      Accept: 'application/json',
     },
     body: JSON.stringify({
       name: file.name,
@@ -52,7 +53,16 @@ export async function uploadModelToIon(file: File): Promise<number> {
     }),
   })
   if (!createRes.ok) {
-    throw new Error(`Failed to create asset: ${createRes.statusText}`)
+    let msg = `Failed to create asset: ${createRes.status} ${createRes.statusText}`
+    try {
+      const data = await createRes.json()
+      if (data && data.message) {
+        msg += ` - ${data.message}`
+      }
+    } catch {
+      // ignore JSON parse errors
+    }
+    throw new Error(msg)
   }
   const createData = (await createRes.json()) as CreateAssetResponse
   const formData = new FormData()

--- a/src/ionUpload.ts
+++ b/src/ionUpload.ts
@@ -1,0 +1,44 @@
+export interface CreateAssetResponse {
+  assetMetadata: { id: number }
+  uploadLocation: {
+    url: string
+    fields: Record<string, string>
+  }
+}
+
+export async function uploadModelToIon(file: File): Promise<number> {
+  const token = import.meta.env.VITE_CESIUM_ION_ACCESS_TOKEN
+  if (!token) {
+    throw new Error('Cesium ion access token is not set')
+  }
+
+  const createRes = await fetch('https://api.cesium.com/v1/assets', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      name: file.name,
+      type: '3DTILES',
+      options: { sourceType: '3D_MODEL' },
+    }),
+  })
+  if (!createRes.ok) {
+    throw new Error(`Failed to create asset: ${createRes.statusText}`)
+  }
+  const createData = (await createRes.json()) as CreateAssetResponse
+  const formData = new FormData()
+  for (const [key, value] of Object.entries(createData.uploadLocation.fields)) {
+    formData.append(key, value)
+  }
+  formData.append('file', file)
+  const uploadRes = await fetch(createData.uploadLocation.url, {
+    method: 'POST',
+    body: formData,
+  })
+  if (!uploadRes.ok) {
+    throw new Error('Upload failed')
+  }
+  return createData.assetMetadata.id
+}


### PR DESCRIPTION
## Summary
- allow uploading 3D models to Cesium ion
- expose new `ModelUploader` component in the app

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684335771004832fb1f0ea4ab885ad39