### PR TITLE
Improve ion upload error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ VITE_CESIUM_ION_ACCESS_TOKEN=your_token_here
 ```
 
 Copy `.env.example` to `.env` and replace the placeholder value. The `.env` file
-is gitignored so your token remains private.
+is gitignored so your token remains private. Ensure the token has permission to
+create and upload assets on Cesium ion, otherwise uploads will fail with an
+authorization error.
 
 Currently, two official plugins are available:
 

--- a/src/CesiumViewer.tsx
+++ b/src/CesiumViewer.tsx
@@ -12,6 +12,7 @@ import {
 import 'cesium/Build/Cesium/Widgets/widgets.css'
 import ToolsPanel from './ToolsPanel'
 import BuildingContextMenu from './BuildingContextMenu'
+import ModelUploader from './ModelUploader'
 
 const ionToken = import.meta.env.VITE_CESIUM_ION_ACCESS_TOKEN
 if (ionToken) {
@@ -95,6 +96,7 @@ const CesiumViewer = () => {
         onContextMenu={(e) => e.preventDefault()}
       />
       <ToolsPanel viewer={viewer} />
+      <ModelUploader viewer={viewer} />
       {contextMenu && (
         <BuildingContextMenu
           x={contextMenu.x}

--- a/src/ModelUploader.tsx
+++ b/src/ModelUploader.tsx
@@ -1,0 +1,91 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  Viewer,
+  ScreenSpaceEventHandler,
+  ScreenSpaceEventType,
+  Cartesian2,
+  Cesium3DTileset,
+  Transforms,
+} from 'cesium'
+import { uploadModelToIon } from './ionUpload'
+
+interface ModelUploaderProps {
+  viewer: Viewer | null
+}
+
+const ModelUploader = ({ viewer }: ModelUploaderProps) => {
+  const [uploading, setUploading] = useState(false)
+  const [assets, setAssets] = useState<{ id: number; name: string }[]>([])
+  const [placingId, setPlacingId] = useState<number | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const handlerRef = useRef<ScreenSpaceEventHandler | null>(null)
+
+  const placeTileset = useCallback(
+    async (assetId: number, position: Cartesian2) => {
+      if (!viewer) return
+      try {
+        const pos =
+          viewer.scene.pickPosition(position) ||
+          viewer.camera.pickEllipsoid(position)
+        if (!pos) return
+        const tileset = await Cesium3DTileset.fromIonAssetId(assetId)
+        tileset.modelMatrix = Transforms.eastNorthUpToFixedFrame(pos)
+        viewer.scene.primitives.add(tileset)
+      } catch {
+        setError('Failed to load tileset')
+      }
+    },
+    [viewer],
+  )
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    setError(null)
+    setUploading(true)
+    try {
+      const id = await uploadModelToIon(file)
+      setAssets((a) => [...a, { id, name: file.name }])
+    } catch (err) {
+      setError((err as Error).message)
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  useEffect(() => {
+    if (!viewer || placingId === null) {
+      return
+    }
+    const handler = new ScreenSpaceEventHandler(viewer.scene.canvas)
+    handlerRef.current = handler
+    handler.setInputAction(async (e: ScreenSpaceEventHandler.PositionedEvent) => {
+      await placeTileset(placingId, e.position)
+      setPlacingId(null)
+      handler.destroy()
+      handlerRef.current = null
+    }, ScreenSpaceEventType.LEFT_CLICK)
+    return () => {
+      handler.destroy()
+      handlerRef.current = null
+    }
+  }, [viewer, placingId, placeTileset])
+
+  return (
+    <div style={{ padding: '1rem', background: 'rgba(255,255,255,0.8)' }}>
+      <input type="file" onChange={handleFileChange} accept=".gltf,.glb,.obj,.fbx" />
+      {uploading && <p>Uploading and processing...</p>}
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      <ul>
+        {assets.map((a) => (
+          <li key={a.id}>
+            <button onClick={() => setPlacingId(a.id)}>Place {a.name}</button>
+          </li>
+        ))}
+      </ul>
+      {placingId && <p>Click on the terrain to place the model...</p>}
+    </div>
+  )
+}
+
+export default ModelUploader

--- a/src/ionUpload.ts
+++ b/src/ionUpload.ts
@@ -70,7 +70,14 @@ export async function uploadModelToIon(file: File): Promise<number> {
     }
     throw new Error(msg)
   }
-  const createData = (await createRes.json()) as CreateAssetResponse
+  const createData = (await createRes.json()) as Partial<CreateAssetResponse>
+  if (
+    !createData.assetMetadata?.id ||
+    !createData.uploadLocation?.url ||
+    !createData.uploadLocation.fields
+  ) {
+    throw new Error('Invalid response from Cesium ion')
+  }
   const formData = new FormData()
   for (const [key, value] of Object.entries(createData.uploadLocation.fields)) {
     formData.append(key, value)

--- a/src/ionUpload.ts
+++ b/src/ionUpload.ts
@@ -48,6 +48,7 @@ export async function uploadModelToIon(file: File): Promise<number> {
     },
     body: JSON.stringify({
       name: file.name,
+      description: 'Uploaded via web app',
       type: '3DTILES',
       options: { sourceType: '3D_MODEL' },
     }),

--- a/src/ionUpload.ts
+++ b/src/ionUpload.ts
@@ -1,0 +1,89 @@
+export interface CreateAssetResponse {
+  assetMetadata: { id: number }
+  uploadLocation: {
+    url: string
+    fields: Record<string, string>
+  }
+}
+
+interface AssetStatusResponse {
+  id: number
+  status: string
+  percentComplete?: number
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function waitForAssetReady(id: number, token: string) {
+  const statusUrl = `https://api.cesium.com/v1/assets/${id}`
+  while (true) {
+    const res = await fetch(statusUrl, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    if (!res.ok) {
+      throw new Error('Failed to check asset status')
+    }
+    const data = (await res.json()) as AssetStatusResponse
+    if (data.status === 'COMPLETE' || data.status === 'READY') {
+      return
+    }
+    await sleep(5000)
+  }
+}
+
+export async function uploadModelToIon(file: File): Promise<number> {
+  const token = import.meta.env.VITE_CESIUM_ION_ACCESS_TOKEN
+  if (!token || token.toLowerCase().includes('token')) {
+    throw new Error('Cesium ion access token is not set')
+  }
+
+  const createRes = await fetch('https://api.cesium.com/v1/assets', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify({
+      name: file.name,
+      type: '3DTILES',
+      options: { sourceType: '3D_MODEL' },
+    }),
+  })
+  if (!createRes.ok) {
+    let msg = `Failed to create asset: ${createRes.status} ${createRes.statusText}`
+    try {
+      const data = await createRes.json()
+      if (data && data.message) {
+        msg += ` - ${data.message}`
+      }
+    } catch {
+      // ignore JSON parse errors
+    }
+    if (createRes.status === 401 || createRes.status === 403) {
+      throw new Error(
+        msg + '. Check that your Cesium ion access token is valid and has write access.',
+      )
+    }
+    throw new Error(msg)
+  }
+  const createData = (await createRes.json()) as CreateAssetResponse
+  const formData = new FormData()
+  for (const [key, value] of Object.entries(createData.uploadLocation.fields)) {
+    formData.append(key, value)
+  }
+  formData.append('file', file)
+  const uploadRes = await fetch(createData.uploadLocation.url, {
+    method: 'POST',
+    body: formData,
+  })
+  if (!uploadRes.ok) {
+    throw new Error('Upload failed')
+  }
+
+  await waitForAssetReady(createData.assetMetadata.id, token)
+
+  return createData.assetMetadata.id
+}


### PR DESCRIPTION
## Summary
- clarify that the Ion access token must allow uploads
- warn when token looks like a placeholder
- include a hint when asset creation returns 401 or 403

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684335771004832fb1f0ea4ab885ad39