### PR TITLE
Add Line tool for 3D objects

### DIFF
--- a/src/Line.tsx
+++ b/src/Line.tsx
@@ -1,0 +1,171 @@
+import { useState, useRef, useEffect } from 'react'
+import {
+  Viewer,
+  ScreenSpaceEventHandler,
+  ScreenSpaceEventType,
+  CallbackProperty,
+  Color,
+  ColorMaterialProperty,
+  ConstantProperty,
+  Cartesian3,
+  HeightReference,
+} from 'cesium'
+import type { AnchorEntity, LineEntity } from './entityTypes'
+import { useDrawing } from './hooks/DrawingContext'
+
+interface LineProps {
+  viewer: Viewer | null
+}
+
+const Line = ({ viewer }: LineProps) => {
+  const handlerRef = useRef<ScreenSpaceEventHandler | null>(null)
+  const startAnchorRef = useRef<AnchorEntity | null>(null)
+  const drawingLineRef = useRef<LineEntity | null>(null)
+  const startPositionRef = useRef<Cartesian3 | null>(null)
+  const mousePositionRef = useRef<Cartesian3 | null>(null)
+  const [isActive, setIsActive] = useState(false)
+
+  const { addAnchor, linesRef } = useDrawing()
+
+  const getPosition = (
+    event: ScreenSpaceEventHandler.PositionedEvent | ScreenSpaceEventHandler.MotionEvent,
+  ): Cartesian3 | null => {
+    const pos = 'position' in event ? event.position : event.endPosition
+    const picked = viewer!.scene.pick(pos)
+    if (picked) {
+      const entity = picked.id as AnchorEntity | undefined
+      if (entity?.isAnchor) {
+        return entity.position?.getValue(viewer!.clock.currentTime) || null
+      }
+    }
+    if (viewer!.scene.pickPositionSupported) {
+      const world = viewer!.scene.pickPosition(pos)
+      if (world) {
+        return world
+      }
+    }
+    const ray = viewer!.camera.getPickRay(pos)
+    if (ray) {
+      const ground = viewer!.scene.globe.pick(ray, viewer!.scene)
+      if (ground) {
+        return ground
+      }
+    }
+    return viewer!.camera.pickEllipsoid(pos) || null
+  }
+
+  const start = () => {
+    if (!viewer) return
+    if (handlerRef.current) {
+      handlerRef.current.destroy()
+      handlerRef.current = null
+      setIsActive(false)
+      if (drawingLineRef.current) {
+        viewer.entities.remove(drawingLineRef.current)
+        drawingLineRef.current = null
+      }
+      if (startAnchorRef.current) {
+        viewer.entities.remove(startAnchorRef.current)
+        startAnchorRef.current = null
+      }
+      startPositionRef.current = null
+      mousePositionRef.current = null
+      return
+    }
+    const handler = new ScreenSpaceEventHandler(viewer.scene.canvas)
+    handlerRef.current = handler
+    setIsActive(true)
+    let isDrawing = false
+
+    handler.setInputAction((event: ScreenSpaceEventHandler.PositionedEvent) => {
+      const position = getPosition(event)
+      if (!position) return
+      if (!isDrawing) {
+        startPositionRef.current = position
+        mousePositionRef.current = position
+        startAnchorRef.current = addAnchor(position, HeightReference.NONE)!
+        const dynamicPositions = new CallbackProperty(() => {
+          if (!startPositionRef.current || !mousePositionRef.current) {
+            return []
+          }
+          return [startPositionRef.current, mousePositionRef.current]
+        }, false)
+        drawingLineRef.current = viewer.entities.add({
+          polyline: {
+            positions: dynamicPositions,
+            width: new ConstantProperty(2),
+            material: new ColorMaterialProperty(Color.YELLOW),
+          },
+        }) as LineEntity
+        isDrawing = true
+      } else {
+        const endAnchor = addAnchor(position, HeightReference.NONE)!
+        const line = drawingLineRef.current!
+        line.polyline!.positions = new ConstantProperty([
+          startPositionRef.current!,
+          position,
+        ])
+        line.isLine = true
+        line.anchors = [startAnchorRef.current!, endAnchor]
+        startAnchorRef.current!.connectedLines.add(line)
+        endAnchor.connectedLines.add(line)
+        linesRef.current.push(line)
+        drawingLineRef.current = null
+        startAnchorRef.current = null
+        startPositionRef.current = null
+        mousePositionRef.current = null
+        isDrawing = false
+        handlerRef.current?.destroy()
+        handlerRef.current = null
+        setIsActive(false)
+      }
+    }, ScreenSpaceEventType.LEFT_CLICK)
+
+    handler.setInputAction((movement: ScreenSpaceEventHandler.MotionEvent) => {
+      if (!isDrawing) return
+      const position = getPosition(movement)
+      if (position) {
+        mousePositionRef.current = position
+      }
+    }, ScreenSpaceEventType.MOUSE_MOVE)
+  }
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && handlerRef.current) {
+        handlerRef.current.destroy()
+        handlerRef.current = null
+        setIsActive(false)
+        if (drawingLineRef.current) {
+          viewer?.entities.remove(drawingLineRef.current)
+          drawingLineRef.current = null
+        }
+        if (startAnchorRef.current) {
+          viewer?.entities.remove(startAnchorRef.current)
+          startAnchorRef.current = null
+        }
+        startPositionRef.current = null
+        mousePositionRef.current = null
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [viewer])
+
+  useEffect(() => {
+    return () => {
+      handlerRef.current?.destroy()
+      handlerRef.current = null
+    }
+  }, [])
+
+  return (
+    <button onClick={start} style={{ border: isActive ? '2px solid yellow' : '1px solid gray' }}>
+      Line
+    </button>
+  )
+}
+
+export default Line

--- a/src/ToolsPanel.tsx
+++ b/src/ToolsPanel.tsx
@@ -1,5 +1,6 @@
 import { Viewer } from 'cesium'
 import LineDrawer from './LineDrawer'
+import Line from './Line'
 import Area from './Area'
 import ExtrusionTool from './ExtrusionTool'
 import TerrainProjectionTool from './TerrainProjectionTool'
@@ -14,6 +15,7 @@ const ToolsPanel = ({ viewer }: ToolsPanelProps) => {
   return (
     <DrawingProvider viewer={viewer}>
       <div className={styles.panel}>
+        <Line viewer={viewer} />
         <LineDrawer viewer={viewer} />
         <Area viewer={viewer} />
         <ExtrusionTool viewer={viewer} />

--- a/src/hooks/DrawingContext.tsx
+++ b/src/hooks/DrawingContext.tsx
@@ -5,7 +5,7 @@ import {
   useCallback,
   type ReactNode,
 } from 'react'
-import { Viewer, Cartesian3 } from 'cesium'
+import { Viewer, Cartesian3, HeightReference } from 'cesium'
 import type { AnchorEntity, LineEntity, AreaEntity } from '../entityTypes'
 import { useDrawingEntities } from './useDrawingEntities'
 
@@ -19,7 +19,10 @@ export interface DrawingContextType {
   unhighlightLine: (line: LineEntity) => void
   highlightAnchor: (anchor: AnchorEntity) => void
   unhighlightAnchor: (anchor: AnchorEntity) => void
-  addAnchor: (position: Cartesian3) => AnchorEntity | null
+  addAnchor: (
+    position: Cartesian3,
+    heightReference?: HeightReference,
+  ) => AnchorEntity | null
   removeLine: (line: LineEntity) => void
   removeAnchor: (anchor: AnchorEntity) => void
   showAxisHelper: (area: AreaEntity) => void

--- a/src/hooks/useDrawingEntities.ts
+++ b/src/hooks/useDrawingEntities.ts
@@ -42,7 +42,10 @@ export function useDrawingEntities(viewer: Viewer | null) {
   }, [])
 
   const addAnchor = useCallback(
-    (position: Cartesian3): AnchorEntity | null => {
+    (
+      position: Cartesian3,
+      heightReference: HeightReference = HeightReference.CLAMP_TO_GROUND,
+    ): AnchorEntity | null => {
       if (!viewer) {
         return null
       }
@@ -59,7 +62,7 @@ export function useDrawingEntities(viewer: Viewer | null) {
           color: Color.ORANGE,
           outlineColor: Color.WHITE,
           outlineWidth: 1,
-          heightReference: HeightReference.CLAMP_TO_GROUND,
+          heightReference,
         },
       }) as AnchorEntity
       anchor.isAnchor = true


### PR DESCRIPTION
## Summary
- add optional `heightReference` parameter for anchors
- expose the new parameter through `DrawingContext`
- implement a new `Line` drawing tool
- register the new tool in the tools panel

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68471575b400832fb0eb3ff937d3f94b