### PR TITLE
Add model texture validation

### DIFF
--- a/src/ModelUploader.tsx
+++ b/src/ModelUploader.tsx
@@ -1,0 +1,66 @@
+import { Viewer, Model } from 'cesium'
+import type { ChangeEvent } from 'react'
+
+interface ModelUploaderProps {
+  viewer: Viewer | null
+}
+
+async function parseGltf(file: File): Promise<Record<string, unknown> | null> {
+  const name = file.name.toLowerCase()
+  if (name.endsWith('.gltf')) {
+    const text = await file.text()
+    return JSON.parse(text) as Record<string, unknown>
+  }
+  const buffer = await file.arrayBuffer()
+  if (buffer.byteLength < 20) {
+    return null
+  }
+  const view = new DataView(buffer)
+  const length = view.getUint32(12, true)
+  const jsonStart = 20
+  const json = new TextDecoder().decode(
+    new Uint8Array(buffer, jsonStart, length),
+  )
+  try {
+    return JSON.parse(json) as Record<string, unknown>
+  } catch {
+    return null
+  }
+}
+
+const ModelUploader = ({ viewer }: ModelUploaderProps) => {
+  const onChange = async (e: ChangeEvent<HTMLInputElement>) => {
+    if (!viewer) return
+    const file = e.target.files?.[0]
+    if (!file) return
+
+    const gltf = await parseGltf(file)
+    const images = (gltf as { images?: unknown[] } | null)?.images
+    const hasTextures = Array.isArray(images) && images.length > 0
+
+    const url = URL.createObjectURL(file)
+    try {
+      const model = await Model.fromGltfAsync({
+        url,
+        incrementallyLoadTextures: true,
+      })
+      viewer.scene.primitives.add(model)
+
+      if (!hasTextures) {
+        alert('Model has no textures defined.')
+      }
+
+      model.texturesReadyEvent.addEventListener(() => {
+        if (hasTextures) {
+          console.log('Textures loaded and applied.')
+        }
+      })
+    } catch (err) {
+      console.error('Failed to load model', err)
+    }
+  }
+
+  return <input type="file" accept=".gltf,.glb" onChange={onChange} />
+}
+
+export default ModelUploader

--- a/src/ToolsPanel.tsx
+++ b/src/ToolsPanel.tsx
@@ -3,6 +3,7 @@ import LineDrawer from './LineDrawer'
 import Area from './Area'
 import ExtrusionTool from './ExtrusionTool'
 import TerrainProjectionTool from './TerrainProjectionTool'
+import ModelUploader from './ModelUploader'
 import { DrawingProvider } from './hooks/DrawingContext'
 import styles from './ToolsPanel.module.css'
 
@@ -18,6 +19,7 @@ const ToolsPanel = ({ viewer }: ToolsPanelProps) => {
         <Area viewer={viewer} />
         <ExtrusionTool viewer={viewer} />
         <TerrainProjectionTool viewer={viewer} />
+        <ModelUploader viewer={viewer} />
       </div>
     </DrawingProvider>
   )


### PR DESCRIPTION
## Summary
- upload glTF/GLB files through a new `ModelUploader` component
- verify textures exist when uploading a model
- report texture status using `texturesReadyEvent`
- expose the model uploader in the tool panel

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6854cf5825cc832fa39815681a8cfc35